### PR TITLE
fix: color string in task edit page wrong on some devices

### DIFF
--- a/lib/pages/project/task_edit.dart
+++ b/lib/pages/project/task_edit.dart
@@ -442,18 +442,14 @@ class _TaskEditPageState extends State<TaskEditPage> {
                           Padding(
                             padding: const EdgeInsets.only(left: 15),
                             child: () {
-                              String? colorString = (_resetColor
-                                      ? null
-                                      : (_color ?? widget.task.color))
-                                  ?.toString();
-                              colorString = colorString
-                                  ?.substring(10, colorString.length - 1)
-                                  .toUpperCase();
-                              colorString = colorString != null
-                                  ? '#$colorString'
-                                  : 'None';
+                              Color? colorString = (_resetColor
+                                  ? null
+                                  : (_color ?? widget.task.color));
+
                               return Text(
-                                '$colorString',
+                                colorString != null
+                                    ? "#${colorString.toHexString()}"
+                                    : "None",
                                 style: TextStyle(
                                   color: Colors.grey,
                                   fontStyle: FontStyle.italic,

--- a/lib/pages/project/task_edit.dart
+++ b/lib/pages/project/task_edit.dart
@@ -442,13 +442,13 @@ class _TaskEditPageState extends State<TaskEditPage> {
                           Padding(
                             padding: const EdgeInsets.only(left: 15),
                             child: () {
-                              Color? colorString = (_resetColor
+                              Color? color = (_resetColor
                                   ? null
                                   : (_color ?? widget.task.color));
 
                               return Text(
-                                colorString != null
-                                    ? "#${colorString.toHexString()}"
+                                color != null
+                                    ? "#${color.toHexString()}"
                                     : "None",
                                 style: TextStyle(
                                   color: Colors.grey,


### PR DESCRIPTION
Colorstring in task edit page was displayed weird on some devices.

<img width="259" height="48" alt="image" src="https://github.com/user-attachments/assets/17840311-fe3b-49f5-9e73-c39e056caebb" />

The calculation is base on toString which is flawed after all.
Replaced by a calculation that is already available and should be more reliable.