### PR TITLE
feature: more intuitive task description editing

### DIFF
--- a/lib/presentation/pages/task/task_edit_page.dart
+++ b/lib/presentation/pages/task/task_edit_page.dart
@@ -162,7 +162,7 @@ class TaskEditPageState extends ConsumerState<TaskEditPage> {
 
   Widget _buildTitle() {
     return Padding(
-      padding: EdgeInsets.symmetric(vertical: 10.0),
+      padding: EdgeInsets.symmetric(vertical: 8.0),
       child: TextFormField(
         maxLines: null,
         keyboardType: TextInputType.multiline,
@@ -181,8 +181,8 @@ class TaskEditPageState extends ConsumerState<TaskEditPage> {
 
   Widget _buildDescription(BuildContext context) {
     return Padding(
-      padding: EdgeInsets.symmetric(vertical: 10.0),
-      child: GestureDetector(
+      padding: EdgeInsets.symmetric(vertical: 8.0),
+      child: InkWell(
         onTap: () async {
           var description = await Navigator.push(
             context,
@@ -199,14 +199,36 @@ class TaskEditPageState extends ConsumerState<TaskEditPage> {
           });
         },
         child: Row(
+          mainAxisSize: MainAxisSize.max,
           children: [
-            Padding(
-              padding: EdgeInsets.only(right: 15, left: 2),
-              child: Icon(Icons.description, color: Colors.grey),
-            ),
-            Flexible(
-              child: HtmlWidget(
-                _description != null ? _description! : "No description",
+            Icon(Icons.description_outlined),
+            Expanded(
+              child: Padding(
+                padding: const EdgeInsets.only(left: 16.0),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(
+                      "Description",
+                      style: Theme.of(context).textTheme.labelMedium?.copyWith(
+                        color: Theme.of(context).hintColor,
+                        fontWeight: FontWeight.normal,
+                      ),
+                    ),
+                    Padding(
+                      padding: const EdgeInsets.only(top: 4.0),
+                      child: Flexible(
+                        child: HtmlWidget(
+                          _description != null &&
+                                  _description?.isNotEmpty == true
+                              ? _description!
+                              : "No description",
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
               ),
             ),
           ],
@@ -217,7 +239,7 @@ class TaskEditPageState extends ConsumerState<TaskEditPage> {
 
   Widget _buildDueDate() {
     return Padding(
-      padding: EdgeInsets.symmetric(vertical: 10.0),
+      padding: EdgeInsets.symmetric(vertical: 8.0),
       child: VikunjaDateTimeField(
         icon: Icon(Icons.access_time),
         label: 'Due Date',
@@ -232,7 +254,7 @@ class TaskEditPageState extends ConsumerState<TaskEditPage> {
 
   Widget _buildStartDate() {
     return Padding(
-      padding: EdgeInsets.symmetric(vertical: 10.0),
+      padding: EdgeInsets.symmetric(vertical: 8.0),
       child: VikunjaDateTimeField(
         label: 'Start Date',
         initialValue: widget.task.startDate,
@@ -246,7 +268,7 @@ class TaskEditPageState extends ConsumerState<TaskEditPage> {
 
   Widget _buildEndDate() {
     return Padding(
-      padding: EdgeInsets.symmetric(vertical: 10.0),
+      padding: EdgeInsets.symmetric(vertical: 8.0),
       child: VikunjaDateTimeField(
         label: 'End Date',
         initialValue: widget.task.endDate,
@@ -260,7 +282,7 @@ class TaskEditPageState extends ConsumerState<TaskEditPage> {
 
   Widget _buildRepeatAfter() {
     return Padding(
-      padding: EdgeInsets.symmetric(vertical: 10.0),
+      padding: EdgeInsets.symmetric(vertical: 8.0),
       child: Row(
         children: [
           Flexible(
@@ -315,7 +337,7 @@ class TaskEditPageState extends ConsumerState<TaskEditPage> {
 
   Widget _buildReminderList() {
     return Padding(
-      padding: EdgeInsets.only(top: 15.0),
+      padding: EdgeInsets.only(top: 8.0),
       child: Column(
         children:
             _reminderDates?.map((e) {
@@ -338,12 +360,12 @@ class TaskEditPageState extends ConsumerState<TaskEditPage> {
 
   Widget _buildAddReminderButton(BuildContext context) {
     return Padding(
-      padding: const EdgeInsets.only(bottom: 15),
+      padding: const EdgeInsets.only(bottom: 16),
       child: GestureDetector(
         child: Row(
           children: <Widget>[
             Padding(
-              padding: EdgeInsets.only(right: 15, left: 2),
+              padding: EdgeInsets.only(right: 16),
               child: Icon(Icons.alarm_add, color: Colors.grey),
             ),
             Text(
@@ -380,7 +402,7 @@ class TaskEditPageState extends ConsumerState<TaskEditPage> {
 
   Widget _buildAddLabel(BuildContext context) {
     return Padding(
-      padding: const EdgeInsets.only(top: 10.0, bottom: 10),
+      padding: const EdgeInsets.symmetric(vertical: 8),
       child: Row(
         children: <Widget>[
           Padding(
@@ -425,7 +447,7 @@ class TaskEditPageState extends ConsumerState<TaskEditPage> {
 
   Widget _buildColor() {
     return Padding(
-      padding: const EdgeInsets.only(top: 15),
+      padding: const EdgeInsets.only(top: 8),
       child: Row(
         children: <Widget>[
           Padding(


### PR DESCRIPTION
Resolves #175 

Added a label to make it easier to find where the description actually is and made the hole row clickable.

<img width="368" height="184" alt="image" src="https://github.com/user-attachments/assets/e791c849-4316-4601-85a3-cada795dbdb6" />


Also adjusted the paddings slightly to make it more consistant