### PR TITLE
build: separate unsigned flavor from production in Android

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -71,6 +71,7 @@ android {
     productFlavors {
         unsigned {
             signingConfig signingConfigs.debug
+            applicationIdSuffix ".unsigned"
         }
         production {
             signingConfig signingConfigs.release

--- a/android/app/src/unsigned/AndroidManifest.xml
+++ b/android/app/src/unsigned/AndroidManifest.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+    <application
+        android:label="Vikunja (Dev)"
+        tools:replace="android:label"/>
+</manifest>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -66,6 +66,7 @@ flutter_icons:
   adaptive_icon_foreground: "assets/vikunja_logo_adaptive.png"
 
 flutter:
+  default-flavor: unsigned
   uses-material-design: true
   assets:
     - assets/graphics/hypnotize.png


### PR DESCRIPTION
- Add .unsigned suffix to application ID for unsigned flavor
- Add "Vikunja (Dev)" app name for unsigned builds
- Set unsigned as default flavor in pubspec.yaml

Allows Android dev builds to be installed alongside production app

<img width="423" height="277" alt="image" src="https://github.com/user-attachments/assets/12d3c29b-04e0-4b96-bb66-ea4c5a7d5cf7" />

