### PR TITLE
fix: update tasks endpoint from /tasks/all to /tasks

### DIFF
--- a/lib/data/data_sources/task_data_source.dart
+++ b/lib/data/data_sources/task_data_source.dart
@@ -70,7 +70,7 @@ class TaskDataSource extends RemoteDataSource {
     };
 
     return await client.get(
-      url: '/tasks/all',
+      url: '/tasks',
       mapper: (body) {
         return convertList(body, (result) => TaskDto.fromJson(result));
       },


### PR DESCRIPTION
Updates the tasks API endpoint from `/tasks/all` to `/tasks` to match the upstream API change (https://github.com/go-vikunja/vikunja/pull/1988)
