### PR TITLE
feat: enable background refresh by default (60 min)

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -26,6 +26,10 @@
 	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>BGTaskSchedulerPermittedIdentifiers</key>
+	<array>
+		<string>workmanager.background.task.update-tasks</string>
+	</array>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>fetch</string>

--- a/lib/core/background_work.dart
+++ b/lib/core/background_work.dart
@@ -71,3 +71,22 @@ Future<bool> updateTasks() async {
 
   return Future.value(true);
 }
+
+/// Registers (or cancels) the periodic background refresh task with the OS.
+///
+/// Call this at app startup and whenever the user changes the interval.
+/// If [minutes] is 0, all existing tasks are cancelled and nothing is registered.
+Future<void> registerBackgroundRefresh(int minutes) async {
+  if (kIsWeb) return;
+
+  await Workmanager().cancelAll();
+  if (minutes > 0) {
+    await Workmanager().registerPeriodicTask(
+      "update-tasks",
+      "update-tasks",
+      frequency: Duration(minutes: minutes),
+      constraints: Constraints(networkType: NetworkType.connected),
+      initialDelay: Duration(seconds: 15),
+    );
+  }
+}

--- a/lib/data/data_sources/settings_data_source.dart
+++ b/lib/data/data_sources/settings_data_source.dart
@@ -42,7 +42,7 @@ class SettingsDatasource {
   Future<int> getRefreshInterval() {
     return _storage
         .read(key: "workmanager-duration")
-        .then((value) => int.tryParse(value ?? "0") ?? 0);
+        .then((value) => int.tryParse(value ?? "60") ?? 60);
   }
 
   Future<void> setRefreshInterval(int minutes) {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -65,7 +65,7 @@
   "enterTitle": "Enter title",
   "limitLabel": "Limit:",
   "backgroundRefreshInterval": "Background Refresh Interval (minutes): ",
-  "noLimitHelper": "Minimum: 15, Set limit of 0 for no refresh",
+  "noLimitHelper": "Minimum: 15, set to 0 to disable. Default: 60 minutes.",
   "addTaskTooltip": "Add task",
   "newBucketName": "New bucket name",
   "bucketExample": "eg. To Do",

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -74,6 +74,8 @@ void main() async {
   try {
     if (!kIsWeb) {
       Workmanager().initialize(callbackDispatcher);
+      final refreshInterval = await settingsDatasource.getRefreshInterval();
+      await registerBackgroundRefresh(refreshInterval);
     }
   } catch (e) {
     developer.log("Failed to initialize workmanager: $e");

--- a/lib/presentation/manager/settings_controller.dart
+++ b/lib/presentation/manager/settings_controller.dart
@@ -1,12 +1,11 @@
-import 'package:flutter/foundation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:vikunja_app/core/background_work.dart';
 import 'package:vikunja_app/core/di/network_provider.dart';
 import 'package:vikunja_app/core/di/repository_provider.dart';
 import 'package:vikunja_app/core/di/theme_provider.dart';
 import 'package:vikunja_app/core/theming/theme_mode.dart';
 import 'package:vikunja_app/domain/entities/project.dart';
 import 'package:vikunja_app/domain/entities/settings_page_state.dart';
-import 'package:workmanager/workmanager.dart';
 
 part 'settings_controller.g.dart';
 
@@ -111,23 +110,8 @@ class SettingsController extends _$SettingsController {
   }
 
   void updateWorkManagerDuration() async {
-    if (kIsWeb) {
-      return;
-    }
-
     var settings = await getAll();
-    Workmanager().cancelAll().then((value) {
-      var duration = Duration(minutes: settings.refreshInterval);
-      if (duration.inMinutes > 0) {
-        Workmanager().registerPeriodicTask(
-          "update-tasks",
-          "update-tasks",
-          frequency: duration,
-          constraints: Constraints(networkType: NetworkType.connected),
-          initialDelay: Duration(seconds: 15),
-        );
-      }
-    });
+    await registerBackgroundRefresh(settings.refreshInterval);
   }
 
   void setDefaultProject(int value) {


### PR DESCRIPTION
Background refresh was disabled by default for new installs, meaning users had to manually discover and enable it. This changes the default to 60 minutes, re-registers the periodic task on every app startup, and fixes iOS where the missing `BGTaskSchedulerPermittedIdentifiers` key caused `workmanager` periodic tasks to silently fail.

- Default refresh interval changed from 0 to 60 minutes (existing user settings preserved)
- WorkManager periodic task re-registered at every app launch
- Extracted shared `registerBackgroundRefresh()` to eliminate duplication between `main()` and `SettingsController`
- Added `BGTaskSchedulerPermittedIdentifiers` to iOS `Info.plist` (required since iOS 13)

Resolves https://github.com/go-vikunja/app/issues/185