### PR TITLE
Android reminder and due date notifications silently fail on Android 12+

### DIFF
--- a/lib/presentation/manager/notifications.dart
+++ b/lib/presentation/manager/notifications.dart
@@ -15,12 +15,13 @@ import 'package:vikunja_app/domain/repositories/task_repository.dart';
 import 'package:vikunja_app/presentation/manager/widget_controller.dart';
 
 const _actionDonePortName = 'action_done_port_name';
+const _notificationActionDone = 'action_done';
 
 @pragma('vm:entry-point')
 Future<void> notificationTapBackground(
   NotificationResponse notificationResponse,
 ) async {
-  if (notificationResponse.actionId == "action_done") {
+  if (notificationResponse.actionId == _notificationActionDone) {
     var id = notificationResponse.id;
 
     if (id != null) {
@@ -78,7 +79,7 @@ class NotificationHandler {
     icon: 'vikunja_notification_logo',
     importance: Importance.high,
     actions: <AndroidNotificationAction>[
-      AndroidNotificationAction('action_dcd one', 'Done'),
+      AndroidNotificationAction(_notificationActionDone, 'Done'),
     ],
   );
   var androidSpecificsReminders = AndroidNotificationDetails(
@@ -88,7 +89,7 @@ class NotificationHandler {
     icon: 'vikunja_notification_logo',
     importance: Importance.high,
     actions: <AndroidNotificationAction>[
-      AndroidNotificationAction('action_done', 'Done'),
+      AndroidNotificationAction(_notificationActionDone, 'Done'),
     ],
   );
   late DarwinNotificationDetails iOSSpecifics;
@@ -114,6 +115,20 @@ class NotificationHandler {
     initBackgroundCommunication();
 
     requestIOSPermissions();
+    await _requestAndroidExactAlarmPermission();
+  }
+
+  Future<void> _requestAndroidExactAlarmPermission() async {
+    final androidPlugin = notificationsPlugin
+        .resolvePlatformSpecificImplementation<
+          AndroidFlutterLocalNotificationsPlugin
+        >();
+    if (androidPlugin == null) return;
+
+    final canSchedule = await androidPlugin.canScheduleExactNotifications();
+    if (canSchedule != true) {
+      await androidPlugin.requestExactAlarmsPermission();
+    }
   }
 
   Future<void> _initNotifications() async {
@@ -128,7 +143,7 @@ class NotificationHandler {
         DarwinNotificationCategory(
           'doneCategory',
           actions: <DarwinNotificationAction>[
-            DarwinNotificationAction.plain('action_done', 'Done'),
+            DarwinNotificationAction.plain(_notificationActionDone, 'Done'),
           ],
         ),
       ],


### PR DESCRIPTION
## Problem

On Android 12+ (API 31+), `SCHEDULE_EXACT_ALARM` is not granted by default and must be requested at runtime. The app calls `zonedSchedule()` with `exactAllowWhileIdle` but never checks or requests this permission, causing all scheduled reminder and due date notifications to fail silently. Test notifications still work because they use `show()` (immediate delivery) rather than `zonedSchedule()`.

Additionally, a typo introduced in a3777dcf sets the due date notification action id to `'action_dcd one'` instead of `'action_done'`, so tapping Done on a due date notification does nothing.

Closes #98

## Changes

- Call `requestExactAlarmsPermission()` during `initNotifications()`, guarded by `canScheduleExactNotifications()` so devices that already have the permission (e.g. via `USE_EXACT_ALARM`) are unaffected
- Fix the `'action_dcd one'` typo by extracting the action id into a named constant `_notificationActionDone` used across all three action definitions and the background handler. This supersedes #268, which fixes the typo alone
 
## Testing
Tested on a Pixel 10 (Android 16, API 36) against a self-hosted Vikunja instance:
- Reminder notification fires while app is in foreground ✓
- Reminder notification fires after app is swiped from recents ✓
- Done action on both reminder and due date notifications marks task complete ✓
- `flutter test` — 174 tests pass ✓
- `dart format --set-exit-if-changed` — no changes ✓